### PR TITLE
fix build/shader compile errors

### DIFF
--- a/Shadows/DepthOnly.hlsl
+++ b/Shadows/DepthOnly.hlsl
@@ -11,7 +11,7 @@
 // ================================================================================================
 // Constant buffers
 // ================================================================================================
-cbuffer VSConstants : register(cb0)
+cbuffer VSConstants : register(b0)
 {
     float4x4 World;
     float4x4 ViewProjection;

--- a/Shadows/SampleFramework11/Shaders/Skybox.hlsl
+++ b/Shadows/SampleFramework11/Shaders/Skybox.hlsl
@@ -11,19 +11,19 @@
 // Constant buffers
 //=================================================================================================
 
-cbuffer VSConstants : register (cb0)
+cbuffer VSConstants : register (b0)
 {
     float4x4 View : packoffset(c0);
     float4x4 Projection : packoffset(c4);
     float3 Bias : packoffset(c8);
 }
 
-cbuffer GSConstants : register(cb0)
+cbuffer GSConstants : register(b0)
 {
   uint RTIndex : packoffset(c0);
 }
 
-cbuffer PSConstants : register (cb0)
+cbuffer PSConstants : register (b0)
 {
     float3 SunDirection : packoffset(c0);
   uint EnableSun : packoffset(c1);

--- a/Shadows/Shadows.cpp
+++ b/Shadows/Shadows.cpp
@@ -116,8 +116,8 @@ void ShadowsApp::Initialize()
 
     ID3D11DeviceContext* context = deviceManager.ImmediateContext();
 
-    Float4x4 meshWorld = Float4x4::ScaleMatrix(MeshScales[AppSettings::CurrentScene]);
-    meshRenderer.SetSceneMesh(context, &models[AppSettings::CurrentScene], meshWorld);
+    Float4x4 meshWorld = Float4x4::ScaleMatrix(MeshScales[(int)AppSettings::CurrentScene]);
+    meshRenderer.SetSceneMesh(context, &models[(int)AppSettings::CurrentScene], meshWorld);
 
     Float4x4 characterWorld = Float4x4::ScaleMatrix(CharacterScale);
     Float4x4 characterOrientation = Quaternion::ToFloat4x4(AppSettings::CharacterOrientation);


### PR DESCRIPTION
I got these errors when building it in VS 2015. The shader compiler errored on `cb0` and asked to replace it with `b0`, and a cast to `int` was necessary because AppSettings::CurrentScene is an `enum class` which can't implicitly be converted to an `int`.
